### PR TITLE
local.conf: Use Wayland instead of X11

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -11,9 +11,6 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 PACKAGE_CLASSES ?= "package_rpm"
 EXTRA_IMAGE_FEATURES_append = " debug-tweaks "
 
-DISTRO_FEATURES_remove = "wayland"
-DISTRO_FEATURES_append = " x11 "
-
 BB_DANGLINGAPPENDS_WARNONLY = "1"
 
 # For GStreamer etc


### PR DESCRIPTION
Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>