### PR TITLE
Conf-qt: Add separate conf for qt-version

### DIFF
--- a/conf-qt/bblayers.conf.sample
+++ b/conf-qt/bblayers.conf.sample
@@ -1,0 +1,26 @@
+LCONF_VERSION = "6"
+
+BBPATH = "${TOPDIR}"
+BSPDIR := "${@os.path.abspath(os.path.dirname(d.getVar('FILE', True)) + '/../..')}"
+
+BBFILES  ?= ""
+BBLAYERS ?= "                                         \
+  ${BSPDIR}/sources/poky/meta                         \
+  ${BSPDIR}/sources/poky/meta-yocto                   \
+  ${BSPDIR}/sources/poky/meta-yocto-bsp               \
+  ${BSPDIR}/sources/meta-openembedded/meta-oe         \
+  ${BSPDIR}/sources/meta-openembedded/meta-networking \
+  ${BSPDIR}/sources/meta-openembedded/meta-python     \
+  ${BSPDIR}/sources/meta-openembedded/meta-ruby       \
+  ${BSPDIR}/sources/meta-ivi/meta-ivi                 \
+  ${BSPDIR}/sources/meta-ivi/meta-ivi-bsp             \
+  ${BSPDIR}/sources/meta-pelux-bsp-intel              \
+  ${BSPDIR}/sources/meta-pelux                        \
+  ${BSPDIR}/sources/meta-intel                        \
+  ${BSPDIR}/sources/meta-virtualization               \
+  ${BSPDIR}/sources/meta-bistro                       \
+  ${BSPDIR}/sources/meta-qt5                          \
+  ${BSPDIR}/sources/meta-boot2qt                      \
+  "
+
+

--- a/conf-qt/layer.conf
+++ b/conf-qt/layer.conf
@@ -1,0 +1,13 @@
+#
+#   Copyright (C) 2016 Pelagicore AB
+#
+# We have a conf and classes directory, append to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a recipes directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "pelux-bsp-intel-layer"
+BBFILE_PATTERN_pelux-bsp-intel-layer := "^${LAYERDIR}/"
+
+BBFILE_PRIORITY_pelux-bsp-intel-layer = "10"

--- a/conf-qt/local.conf.sample
+++ b/conf-qt/local.conf.sample
@@ -1,0 +1,20 @@
+CONF_VERSION = "1"
+DL_DIR = "${TOPDIR}/downloads"
+
+MACHINE = "intel-corei7-64"
+SDKMACHINE = "i686"
+DISTRO = "bistro"
+
+BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
+PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
+
+PACKAGE_CLASSES ?= "package_rpm"
+EXTRA_IMAGE_FEATURES_append = " debug-tweaks "
+
+DISTRO_FEATURES_append = " opengl "
+
+BB_DANGLINGAPPENDS_WARNONLY = "1"
+
+# For GStreamer etc
+LICENSE_FLAGS_WHITELIST = "commercial license"
+


### PR DESCRIPTION
Since the qt build needs to include "meta-boot2qt" in the bblayers.conf there is a need for separate conf files.
Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>