### PR TITLE
conf-notes: Add information of available images

### DIFF
--- a/conf/conf-notes.txt
+++ b/conf/conf-notes.txt
@@ -1,0 +1,5 @@
+Available PELUX images:
+* core-image-pelux
+* core-image-pelux-qt
+
+Build them by running: bitbake <image>


### PR DESCRIPTION
Add conf-notes.txt which contains information about what PELUX images
there are avaiable for building using bitbake.

This is related to the issue in pelux-manifests about conf-notes created by @erikboto 

Signed-off-by: Viktor Sjölind <viktor.sjolind@pelagicore.com>