### PR TITLE
base-files: override empty fstab from meta-bistro so / is remount rea…

### DIFF
--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -1,0 +1,1 @@
+/dev/root            /                    auto       defaults              1  1

--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -1,0 +1,6 @@
+#
+#   Copyright (C) 2017 Pelagicore AB
+#
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://fstab"
+


### PR DESCRIPTION
…d-write

Signed-off-by: Erik Botö <erik.boto@pelagicore.com>

Since we're using an initramfs on Intel which only mounts root as read-only, we need an entry in fstab so that it is remounted read-write during boot.