### PR TITLE
base-files: remove default fstab

### DIFF
--- a/recipes-core/base-files/base-files/fstab
+++ b/recipes-core/base-files/base-files/fstab
@@ -1,1 +1,0 @@
-/dev/root            /                    auto       defaults              1  1

--- a/recipes-core/base-files/base-files_3.0.14.bbappend
+++ b/recipes-core/base-files/base-files_3.0.14.bbappend
@@ -1,6 +1,0 @@
-#
-#   Copyright (C) 2017 Pelagicore AB
-#
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI += "file://fstab"
-


### PR DESCRIPTION
The default fstab has been moved to meta-pelux layer.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>