### PR TITLE
local.conf: Build SDK for x86_64

### DIFF
--- a/conf-qt/local.conf.sample
+++ b/conf-qt/local.conf.sample
@@ -2,7 +2,7 @@ CONF_VERSION = "1"
 DL_DIR = "${TOPDIR}/downloads"
 
 MACHINE = "intel-corei7-64"
-SDKMACHINE = "i686"
+SDKMACHINE = "x86_64"
 DISTRO = "bistro"
 
 BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -2,7 +2,7 @@ CONF_VERSION = "1"
 DL_DIR = "${TOPDIR}/downloads"
 
 MACHINE = "intel-corei7-64"
-SDKMACHINE = "i686"
+SDKMACHINE = "x86_64"
 DISTRO = "bistro"
 
 BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"


### PR DESCRIPTION
Let's build SDK for x86_64 arch instead of i686.