### PR TITLE
Rename core-image-pelux-qt to core-image-pelux-qtauto

### DIFF
--- a/conf/conf-notes.txt
+++ b/conf/conf-notes.txt
@@ -1,5 +1,5 @@
 Available PELUX images:
 * core-image-pelux
-* core-image-pelux-qt
+* core-image-pelux-qtauto
 
 Build them by running: bitbake <image>


### PR DESCRIPTION
This was done in order to explicitly reflect that the qtauto image adds
Qt Automotive Suite components, while the regular image includes Qt minus
those components.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>