### PR TITLE
bblayers.conf: Add template layer

### DIFF
--- a/conf-qt/bblayers.conf.sample
+++ b/conf-qt/bblayers.conf.sample
@@ -20,6 +20,7 @@ BBLAYERS ?= "                                         \
   ${BSPDIR}/sources/meta-intel                        \
   ${BSPDIR}/sources/meta-virtualization               \
   ${BSPDIR}/sources/meta-bistro                       \
+  ${BSPDIR}/sources/meta-template                     \
   ${BSPDIR}/sources/meta-qt5                          \
   ${BSPDIR}/sources/meta-boot2qt                      \
   "

--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -20,6 +20,7 @@ BBLAYERS ?= "                                         \
   ${BSPDIR}/sources/meta-intel                        \
   ${BSPDIR}/sources/meta-virtualization               \
   ${BSPDIR}/sources/meta-bistro                       \
+  ${BSPDIR}/sources/meta-template                     \
   ${BSPDIR}/sources/meta-qt5                          \
   "
 


### PR DESCRIPTION
The template layer is used as an example layer that provides a basic
layer with template structure, configuration and template component
recipes.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>