### PR TITLE
remove qtauto image from available images / reformat README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ Maintained at https://github.com/pelagicore/meta-pelux
 
 Branching
 ---------
-This repository will follow the yocto release system. Whenever a new yocto release has been released, a new branch with the same name will be created from the master branch. All feature growth should happen first on the master branch, but will also be cherry picked back to the latest yocto release branch. Security and bug fixes will be evaluated case by case and backported as necessary. The ambition is to actively maintain the four latest releases and/or two year old releases in this fashion.
+This repository will follow the yocto release system. Whenever a new yocto
+release has been released, a new branch with the same name will be created from
+the master branch. All feature growth should happen first on the master branch,
+but will also be cherry picked back to the latest yocto release branch. Security
+and bug fixes will be evaluated case by case and backported as necessary.  The
+ambition is to actively maintain the four latest releases and/or two year old
+releases in this
+fashion.
 
 License and Copyright
 ---------------------
 Copyright (C) 2016 Pelagicore AB
 
-All metadata is MIT licensed unless otherwise stated. Source code included in tree for individual recipes is under the LICENSE stated in the associated recipe (.bb file) unless otherwise stated.
+All metadata is MIT licensed unless otherwise stated. Source code included in
+tree for individual recipes is under the LICENSE stated in the associated recipe
+(.bb file) unless otherwise stated.
 
-License information for any other files is either explicitly stated or defaults to MIT license.
+License information for any other files is either explicitly stated or defaults
+to MIT license.

--- a/conf-qt/conf-notes.txt
+++ b/conf-qt/conf-notes.txt
@@ -1,4 +1,5 @@
 Available PELUX images:
 * core-image-pelux
+* core-image-pelux-qtauto
 
 Build them by running: bitbake <image>


### PR DESCRIPTION
With b2qt being conditional in meta-pelux, we only show this image as
suggested image when we are building with b2qt support. This requires a
change in the manifest to copy that file.

Signed-off-by: Tobias Olausson <tobias.olausson@pelagicore.com>